### PR TITLE
Add FastAPI backend and Vue frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.venv/
+node_modules/
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ pdf2anki/
 
 ```bash
 cd backend
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 uvicorn app:app --reload
 ```
 
+> **Note:** Some Linux distributions do not ship a `python` shim by default.
+> If `python` is not found, install the `python-is-python3` package or use
+> `python3` in the commands above.
+
 ### Frontend
+
+The Vite tooling requires **Node.js 18 or newer**. If your system Node is
+older, switch versions with a tool like `nvm` before running the dev server.
 
 ```bash
 cd frontend

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Prototype web app that turns course PDFs into review-ready Anki decks.
 
+The backend now defaults to an LLM-first extraction flow: uploaded PDFs are
+segmented, chunked to fit the model context window, and each chunk is analysed by
+an OpenAI model to produce grounded flashcards. When no API key is configured,
+the service automatically falls back to the heuristic extractors described
+below.
+
 ## Project structure
 
 ```
@@ -53,25 +59,25 @@ The backend combines lightweight NLP heuristics to produce higher quality cards:
 
 You can tweak the generation by changing the `language`, `card_types`, or `max_cards` parameters sent from the frontend.
 
-### Optional LLM polishing
+### LLM-backed extraction
 
-If you want richer phrasing, short rationales, or better tag suggestions, provide
-an OpenAI API key and enable the *Enhance with AI* toggle in the frontend. The
-backend will pass the generated cards through `gpt-4o-mini` (or the model you
-configure) to rewrite the question/answer pair while staying faithful to the
-original PDF snippet.
+Provide an OpenAI API key to let the backend generate cards directly from PDF
+chunks. The service keeps each prompt under a configurable token budget and
+streams the chunks sequentially so even long documents stay within model limits.
 
 ```bash
 export OPENAI_API_KEY=sk-your-key
-# Optional: override defaults
-export OPENAI_MODEL=gpt-4o-mini    # any Responses/Chat model works
-export LLM_REFINEMENT_LIMIT=20     # max cards polished per request
+# Optional overrides
+export OPENAI_EXTRACTION_MODEL=gpt-4o-mini     # default model for extraction
+export LLM_MAX_CHUNK_TOKENS=3200               # rough cap per prompt
+export LLM_CHUNK_OVERLAP_TOKENS=200            # overlap between chunks
 ```
 
-With a key in place, the `/extract` response contains an `llm` report detailing
-whether refinement happened, how many cards were enriched, and how long it took.
-If no key is configured, the API responds with `used: false` and the frontend
-explains that AI polishing was skipped.
+The `/extract` endpoint returns an `llm` report detailing how many cards the
+model generated, how many chunks were needed, which model served the request, and
+any failure messages. When the key is missing or a call fails, the backend
+gracefully switches to the heuristic extractors so users still receive candidate
+cards.
 
 ## Pushing your changes
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ The backend combines lightweight NLP heuristics to produce higher quality cards:
 
 You can tweak the generation by changing the `language`, `card_types`, or `max_cards` parameters sent from the frontend.
 
+### Optional LLM polishing
+
+If you want richer phrasing, short rationales, or better tag suggestions, provide
+an OpenAI API key and enable the *Enhance with AI* toggle in the frontend. The
+backend will pass the generated cards through `gpt-4o-mini` (or the model you
+configure) to rewrite the question/answer pair while staying faithful to the
+original PDF snippet.
+
+```bash
+export OPENAI_API_KEY=sk-your-key
+# Optional: override defaults
+export OPENAI_MODEL=gpt-4o-mini    # any Responses/Chat model works
+export LLM_REFINEMENT_LIMIT=20     # max cards polished per request
+```
+
+With a key in place, the `/extract` response contains an `llm` report detailing
+whether refinement happened, how many cards were enriched, and how long it took.
+If no key is configured, the API responds with `used: false` and the frontend
+explains that AI polishing was skipped.
+
 ## Pushing your changes
 
 This template repository does not ship with a remote configured. To publish the

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ uvicorn app:app --reload
 
 ### Frontend
 
-The Vite tooling requires **Node.js 18 or newer**. If your system Node is
-older, switch versions with a tool like `nvm` before running the dev server.
+The frontend is pinned to Vite 4 so it works with **Node.js 16.20+**.
+Using a newer LTS (18/20) is still recommended, but no longer required to run
+the development server. If you do switch Node versions with a tool such as
+`nvm`, reinstall dependencies afterwards.
 
 ```bash
 cd frontend

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ npm run dev
 
 The development server proxies API calls to the FastAPI instance running on port 8000.
 
+## Card extraction heuristics
+
+The backend combines lightweight NLP heuristics to produce higher quality cards:
+
+* **Definitions** — detects "is/are", "est/sont", and colon-based statements in English and French.
+* **Enumerations** — understands bullet lists, numbered steps, and sentences such as "X consists of …" to build Q/A and cloze cards.
+* **Section summaries** — reuses detected headings to create concise recap questions for longer paragraphs.
+* **Language-aware prompts** — question templates automatically switch between English and French based on the `language` field provided in the `/extract` request.
+
+You can tweak the generation by changing the `language`, `card_types`, or `max_cards` parameters sent from the frontend.
+
 ## Pushing your changes
 
 This template repository does not ship with a remote configured. To publish the

--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ npm run dev
 ```
 
 The development server proxies API calls to the FastAPI instance running on port 8000.
+
+## Pushing your changes
+
+This template repository does not ship with a remote configured. To publish the
+current branch to your own Git remote:
+
+```bash
+# inside the project root
+git remote add origin <your-repo-url>
+git push -u origin work
+```
+
+Replace `<your-repo-url>` with the HTTPS or SSH URL of a repository you own
+(for example, one created on GitHub). Subsequent pushes can use `git push`
+without additional arguments once the upstream has been set.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # pdf2anki
-Give me a pdf document, I will create for you an anki deck to help you with your revision
+
+Prototype web app that turns course PDFs into review-ready Anki decks.
+
+## Project structure
+
+```
+pdf2anki/
+├─ backend/         # FastAPI service for extraction + Anki export
+└─ frontend/        # Vue 3 single-page app (Vite + Tailwind)
+```
+
+## Getting started
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The development server proxies API calls to the FastAPI instance running on port 8000.

--- a/backend/app.py
+++ b/backend/app.py
@@ -33,8 +33,10 @@ async def extract_cards(request: ExtractRequest, pdf_id: str):
 
     pages = pdf_reader.read_pdf(PDF_STORAGE[pdf_id])
     sections = segmenter.split_into_sections(pages)
-    facts = extractor.extract_facts(sections)
-    cards = cardgen.generate_cards(facts, request.card_types, request.max_cards)
+    facts = extractor.extract_facts(sections, request.language)
+    cards = cardgen.generate_cards(
+        facts, request.card_types, request.max_cards, request.language
+    )
     cards = quality.apply_checks(cards)
     metrics = {"pages": len(pages), "candidates": len(cards)}
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,53 @@
+import io
+import uuid
+
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from models import ExportRequest, ExtractRequest, ExtractResponse
+
+import cardgen
+import extractor
+import pdf_reader
+import quality
+import segmenter
+import exporter
+
+app = FastAPI(title="PDF → Anki")
+
+PDF_STORAGE: dict[str, bytes] = {}
+
+
+@app.post("/upload")
+async def upload_pdf(file: UploadFile = File(...)):
+    payload = await file.read()
+    pdf_id = uuid.uuid4().hex[:8]
+    PDF_STORAGE[pdf_id] = payload
+    return {"pdf_id": pdf_id, "filename": file.filename, "size": len(payload)}
+
+
+@app.post("/extract", response_model=ExtractResponse)
+async def extract_cards(request: ExtractRequest, pdf_id: str):
+    if pdf_id not in PDF_STORAGE:
+        return JSONResponse({"error": "pdf_id not found"}, status_code=404)
+
+    pages = pdf_reader.read_pdf(PDF_STORAGE[pdf_id])
+    sections = segmenter.split_into_sections(pages)
+    facts = extractor.extract_facts(sections)
+    cards = cardgen.generate_cards(facts, request.card_types, request.max_cards)
+    cards = quality.apply_checks(cards)
+    metrics = {"pages": len(pages), "candidates": len(cards)}
+
+    return ExtractResponse(cards=cards, metrics=metrics)
+
+
+@app.post("/export.apkg")
+async def export_apkg(body: ExportRequest):
+    package = exporter.build_apkg(body.deck_name, body.cards)
+    return StreamingResponse(
+        io.BytesIO(package),
+        media_type="application/octet-stream",
+        headers={
+            "Content-Disposition": f'attachment; filename="{body.deck_name}.apkg"'
+        },
+    )

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from models import ExportRequest, ExtractRequest, ExtractResponse
 
 import cardgen
 import extractor
+import llm_refiner
 import pdf_reader
 import quality
 import segmenter
@@ -38,9 +39,14 @@ async def extract_cards(request: ExtractRequest, pdf_id: str):
         facts, request.card_types, request.max_cards, request.language
     )
     cards = quality.apply_checks(cards)
-    metrics = {"pages": len(pages), "candidates": len(cards)}
+    llm_report = None
+    if request.use_llm:
+        cards, llm_metrics = await llm_refiner.refine_cards(cards, request.language)
+        cards = quality.apply_checks(cards)
+        llm_report = llm_metrics
+    metrics = {"pages": float(len(pages)), "candidates": float(len(cards))}
 
-    return ExtractResponse(cards=cards, metrics=metrics)
+    return ExtractResponse(cards=cards, metrics=metrics, llm=llm_report)
 
 
 @app.post("/export.apkg")

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from models import ExportRequest, ExtractRequest, ExtractResponse
 
 import cardgen
 import extractor
-import llm_refiner
+import llm_extractor
 import pdf_reader
 import quality
 import segmenter
@@ -34,16 +34,32 @@ async def extract_cards(request: ExtractRequest, pdf_id: str):
 
     pages = pdf_reader.read_pdf(PDF_STORAGE[pdf_id])
     sections = segmenter.split_into_sections(pages)
-    facts = extractor.extract_facts(sections, request.language)
-    cards = cardgen.generate_cards(
-        facts, request.card_types, request.max_cards, request.language
-    )
-    cards = quality.apply_checks(cards)
-    llm_report = None
+
+    cards: list[dict[str, object]] = []
+    llm_report: dict[str, object] | None = None
+
     if request.use_llm:
-        cards, llm_metrics = await llm_refiner.refine_cards(cards, request.language)
-        cards = quality.apply_checks(cards)
-        llm_report = llm_metrics
+        cards, llm_metrics = await llm_extractor.generate_cards(
+            sections, request.language or "en", request.card_types, request.max_cards
+        )
+        llm_report = {
+            "used": llm_metrics.get("used", False),
+            "generated": int(llm_metrics.get("generated", 0)),
+            "enriched": int(llm_metrics.get("generated", 0)),
+            "model": llm_metrics.get("model"),
+            "duration_ms": int(llm_metrics.get("duration_ms", 0)),
+            "chunks": int(llm_metrics.get("chunks", 0)),
+            "error": llm_metrics.get("error"),
+            "mode": "extraction",
+        }
+
+    if not cards:
+        facts = extractor.extract_facts(sections, request.language)
+        cards = cardgen.generate_cards(
+            facts, request.card_types, request.max_cards, request.language
+        )
+
+    cards = quality.apply_checks(cards)
     metrics = {"pages": float(len(pages)), "candidates": float(len(cards))}
 
     return ExtractResponse(cards=cards, metrics=metrics, llm=llm_report)

--- a/backend/cardgen.py
+++ b/backend/cardgen.py
@@ -46,6 +46,7 @@ def _make_card(
     page: int,
     source: str,
     tags: List[str],
+    explanation: str | None = None,
 ) -> Dict[str, object]:
     return {
         "id": _new_id(),
@@ -56,6 +57,7 @@ def _make_card(
         "source_page": page,
         "confidence": _confidence(question, answer),
         "source_snippet": source,
+        "explanation": explanation,
     }
 
 

--- a/backend/cardgen.py
+++ b/backend/cardgen.py
@@ -1,5 +1,28 @@
+import re
 import uuid
 from typing import Dict, List
+
+
+LANGUAGE_CONFIG = {
+    "en": {
+        "definition_question": "What is **{term}**?",
+        "definition_alt": "Explain **{term}**.",
+        "list_question": "List the key points about **{title}**.",
+        "summary_question": "Summarize **{title}**.",
+        "list_intro": "The main elements of {title} are {items}.",
+        "enum_separator": ", ",
+        "enum_last_separator": " and ",
+    },
+    "fr": {
+        "definition_question": "Qu'est-ce que **{term}** ?",
+        "definition_alt": "Expliquez **{term}**.",
+        "list_question": "Citez les points clés concernant **{title}**.",
+        "summary_question": "Résumez **{title}**.",
+        "list_intro": "Les éléments principaux de {title} sont {items}.",
+        "enum_separator": ", ",
+        "enum_last_separator": " et ",
+    },
+}
 
 
 def _new_id() -> str:
@@ -40,55 +63,198 @@ def generate_cards(
     facts: List[Dict[str, object]],
     card_types: List[str],
     max_cards: int,
+    language: str = "en",
 ) -> List[Dict[str, object]]:
     cards: List[Dict[str, object]] = []
+    normalised_language = _normalise_language(language)
+    config = LANGUAGE_CONFIG.get(normalised_language, LANGUAGE_CONFIG["en"])
 
     for fact in facts:
-        if fact["kind"] == "definition":
-            if "qa" in card_types:
-                question = f"What is **{fact['term']}**?"
-                answer = fact["desc"]
-                cards.append(
-                    _make_card(
-                        "qa",
-                        question,
-                        answer,
-                        fact["page"],
-                        fact["source"],
-                        ["definition"],
-                    )
-                )
-            if "cloze" in card_types and 10 < len(fact["desc"]) < 200:
-                sentence = f"{fact['term']} is {fact['desc']}"
-                if fact["term"] in sentence:
-                    cloze = sentence.replace(
-                        fact["term"], f"{{{{c1::{fact['term']}}}}}"
-                    )
-                    cards.append(
-                        _make_card(
-                            "cloze",
-                            cloze,
-                            "",
-                            fact["page"],
-                            fact["source"],
-                            ["definition", "cloze"],
-                        )
-                    )
-        elif fact["kind"] == "list" and "qa" in card_types:
-            question = f"List the key points: {fact['title']}"
-            answer = "; ".join(fact["items"])
-            cards.append(
-                _make_card(
-                    "qa",
-                    question,
-                    answer,
-                    fact["page"],
-                    fact["source"],
-                    ["list"],
+        kind = fact["kind"]
+        if kind == "definition":
+            cards.extend(
+                _definition_cards(
+                    fact,
+                    card_types,
+                    config,
+                    normalised_language,
                 )
             )
+        elif kind == "list":
+            cards.extend(_list_cards(fact, card_types, config))
+        elif kind == "summary":
+            cards.extend(_summary_cards(fact, card_types, config))
 
         if len(cards) >= max_cards:
             break
 
+    return cards[:max_cards]
+
+
+def _definition_cards(
+    fact: Dict[str, object],
+    card_types: List[str],
+    config: Dict[str, str],
+    language: str,
+) -> List[Dict[str, object]]:
+    cards: List[Dict[str, object]] = []
+    term = fact["term"]
+    description = fact["desc"]
+
+    if "qa" in card_types:
+        question = config["definition_question"].format(term=term)
+        cards.append(
+            _make_card(
+                "qa",
+                question,
+                description,
+                fact["page"],
+                fact["source"],
+                ["definition", _slugify(term)],
+            )
+        )
+
+    if "qa" in card_types and len(description.split()) > 25:
+        concise = _first_sentences(description, 2)
+        if concise and concise != description:
+            question = config["definition_alt"].format(term=term)
+            cards.append(
+                _make_card(
+                    "qa",
+                    question,
+                    concise,
+                    fact["page"],
+                    fact["source"],
+                    ["definition", "focus", _slugify(term)],
+                )
+            )
+
+    if "cloze" in card_types and 10 < len(description) < 220:
+        if description.lower().startswith(("is", "est")):
+            base_sentence = f"{term} {description}"
+        else:
+            linking = _linking_verb(description, language)
+            base_sentence = f"{term} {linking} {description}" if linking else f"{term} {description}"
+        sentence = re.sub(r"\s+", " ", base_sentence).strip()
+        if term in sentence:
+            cloze_sentence = sentence.replace(term, f"{{{{c1::{term}}}}}", 1)
+            cards.append(
+                _make_card(
+                    "cloze",
+                    cloze_sentence,
+                    "",
+                    fact["page"],
+                    fact["source"],
+                    ["definition", "cloze", _slugify(term)],
+                )
+            )
+
     return cards
+
+
+def _list_cards(
+    fact: Dict[str, object], card_types: List[str], config: Dict[str, str]
+) -> List[Dict[str, object]]:
+    cards: List[Dict[str, object]] = []
+    items = fact["items"]
+
+    if "qa" in card_types:
+        question = config["list_question"].format(title=fact["title"])
+        answer = "; ".join(items)
+        cards.append(
+            _make_card(
+                "qa",
+                question,
+                answer,
+                fact["page"],
+                fact["source"],
+                ["list", _slugify(fact["title"])],
+            )
+        )
+
+    if "cloze" in card_types and 2 <= len(items) <= 6:
+        formatted_items = _format_enumeration(
+            [f"{{{{c{index}::{item}}}}}" for index, item in enumerate(items, start=1)],
+            config,
+        )
+        sentence = config["list_intro"].format(
+            title=fact["title"],
+            items=formatted_items,
+        )
+        cards.append(
+            _make_card(
+                "cloze",
+                sentence,
+                "",
+                fact["page"],
+                fact["source"],
+                ["list", "cloze", _slugify(fact["title"])],
+            )
+        )
+
+    return cards
+
+
+def _summary_cards(
+    fact: Dict[str, object],
+    card_types: List[str],
+    config: Dict[str, str],
+) -> List[Dict[str, object]]:
+    if "qa" not in card_types:
+        return []
+    question = config["summary_question"].format(title=fact["title"])
+    answer = fact["summary"]
+    return [
+        _make_card(
+            "qa",
+            question,
+            answer,
+            fact["page"],
+            fact["source"],
+            ["summary", _slugify(fact["title"])],
+        )
+    ]
+
+
+def _format_enumeration(items: List[str], config: Dict[str, str]) -> str:
+    if len(items) == 1:
+        return items[0]
+    return config["enum_separator"].join(items[:-1]) + config["enum_last_separator"] + items[-1]
+
+
+def _slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-") or "note"
+
+
+def _first_sentences(text: str, limit: int) -> str:
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    selected = []
+    for sentence in sentences:
+        clean = sentence.strip()
+        if not clean:
+            continue
+        selected.append(clean)
+        if len(selected) >= limit:
+            break
+    return " ".join(selected)
+
+
+def _normalise_language(language: str | None) -> str:
+    if not language:
+        return "en"
+    language = language.lower()
+    if language.startswith("fr"):
+        return "fr"
+    if language.startswith("en"):
+        return "en"
+    return "en"
+
+
+def _linking_verb(description: str, language: str) -> str:
+    if description.lower().startswith(("is", "est")):
+        return ""
+    if language == "fr":
+        return "est"
+    return "is"

--- a/backend/cardgen.py
+++ b/backend/cardgen.py
@@ -1,0 +1,94 @@
+import uuid
+from typing import Dict, List
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _confidence(question: str, answer: str) -> float:
+    qlen, alen = len(question), len(answer)
+    score = 1.0
+    if qlen < 12 or qlen > 220:
+        score -= 0.2
+    if alen > 260:
+        score -= 0.2
+    return max(0.3, min(1.0, score))
+
+
+def _make_card(
+    card_type: str,
+    question: str,
+    answer: str,
+    page: int,
+    source: str,
+    tags: List[str],
+) -> Dict[str, object]:
+    return {
+        "id": _new_id(),
+        "type": card_type,
+        "question": question.strip(),
+        "answer": answer.strip(),
+        "tags": tags,
+        "source_page": page,
+        "confidence": _confidence(question, answer),
+        "source_snippet": source,
+    }
+
+
+def generate_cards(
+    facts: List[Dict[str, object]],
+    card_types: List[str],
+    max_cards: int,
+) -> List[Dict[str, object]]:
+    cards: List[Dict[str, object]] = []
+
+    for fact in facts:
+        if fact["kind"] == "definition":
+            if "qa" in card_types:
+                question = f"What is **{fact['term']}**?"
+                answer = fact["desc"]
+                cards.append(
+                    _make_card(
+                        "qa",
+                        question,
+                        answer,
+                        fact["page"],
+                        fact["source"],
+                        ["definition"],
+                    )
+                )
+            if "cloze" in card_types and 10 < len(fact["desc"]) < 200:
+                sentence = f"{fact['term']} is {fact['desc']}"
+                if fact["term"] in sentence:
+                    cloze = sentence.replace(
+                        fact["term"], f"{{{{c1::{fact['term']}}}}}"
+                    )
+                    cards.append(
+                        _make_card(
+                            "cloze",
+                            cloze,
+                            "",
+                            fact["page"],
+                            fact["source"],
+                            ["definition", "cloze"],
+                        )
+                    )
+        elif fact["kind"] == "list" and "qa" in card_types:
+            question = f"List the key points: {fact['title']}"
+            answer = "; ".join(fact["items"])
+            cards.append(
+                _make_card(
+                    "qa",
+                    question,
+                    answer,
+                    fact["page"],
+                    fact["source"],
+                    ["list"],
+                )
+            )
+
+        if len(cards) >= max_cards:
+            break
+
+    return cards

--- a/backend/exporter.py
+++ b/backend/exporter.py
@@ -1,0 +1,61 @@
+import io
+import random
+from typing import Dict, List
+
+import genanki
+
+
+def build_apkg(deck_name: str, cards: List[Dict[str, object]]) -> bytes:
+    deck_id = random.randrange(1 << 30, 1 << 31)
+    model_id = random.randrange(1 << 30, 1 << 31)
+
+    model = genanki.Model(
+        model_id,
+        "PDF2Anki Cloze+QA",
+        fields=[
+            {"name": "Question"},
+            {"name": "Answer"},
+            {"name": "Tags"},
+            {"name": "Source"},
+        ],
+        templates=[
+            {
+                "name": "QA Card",
+                "qfmt": "<div class='q'>{{Question}}</div><div class='src'>{{Source}}</div>",
+                "afmt": "{{FrontSide}}<hr id='answer'><div class='a'>{{Answer}}</div>",
+            },
+            {
+                "name": "Cloze Card",
+                "qfmt": "{{cloze:Question}}<div class='src'>{{Source}}</div>",
+                "afmt": "{{cloze:Question}}<hr id='answer'><div class='a'>{{Answer}}</div>",
+            },
+        ],
+        css="""
+            .card { font-family: Inter, Arial; font-size: 16px; line-height: 1.5; }
+            .q { font-weight: 600; }
+            .src { color: #888; font-size: 12px; margin-top: 8px; }
+            .a { margin-top: 10px; }
+        """,
+    )
+
+    deck = genanki.Deck(deck_id, deck_name)
+    for card in cards:
+        note = genanki.Note(
+            model=model,
+            fields=[
+                card["question"],
+                card["answer"],
+                " ".join(card["tags"]),
+                f"p.{card['source_page']}",
+            ],
+            guid=card["id"],
+            tags=card["tags"],
+        )
+        if card["type"] == "cloze":
+            note.model()["type"] = 1
+        deck.add_note(note)
+
+    package = genanki.Package(deck)
+    buffer = io.BytesIO()
+    package.write_to_file(buffer)
+    return buffer.getvalue()

--- a/backend/extractor.py
+++ b/backend/extractor.py
@@ -1,48 +1,196 @@
 import re
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
 
 DEFINITION_PATTERN = re.compile(
-    r"(?:Definition[:\-]\s*)?(.{2,60}?)\s+(?:is|are|est|sont)\s+(.{10,250})",
+    r"(?:Definition[:\-]\s*)?(.{2,60}?)\s+(?:is|are|refers to|means|est|sont|désigne)\s+(.{10,250})",
     flags=re.IGNORECASE,
 )
+COLON_DEFINITION_PATTERN = re.compile(
+    r"^(?:\d+\.\s*)?(.{2,70}?)\s*[:\-–—]\s+(.{10,250})$",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+ENUMERATION_PATTERNS: Iterable[re.Pattern[str]] = (
+    re.compile(r"(.+?)\s+(?:consists of|includes|comprises|contains)\s+(.+)", re.IGNORECASE),
+    re.compile(
+        r"(.+?)\s+(?:se compose de|comprend|comprennent|inclut|incluent)\s+(.+)",
+        re.IGNORECASE,
+    ),
+)
+SENTENCE_SPLIT_PATTERN = re.compile(r"(?<=[.!?])\s+(?=[A-ZÉÈÊÀÂÇÎÔÙ0-9])")
 
 
-def extract_facts(sections: List[Dict[str, str]]) -> List[Dict[str, object]]:
-    """Identify definition and list facts from section text."""
+def extract_facts(
+    sections: List[Dict[str, str]], language: str = "en"
+) -> List[Dict[str, object]]:
+    """Identify definition, list and summary facts from section text."""
+
     facts: List[Dict[str, object]] = []
+    normalized_language = _normalise_language(language)
+
+    seen_definitions = set()
+
     for section in sections:
         text = section["text"]
+        raw_text = section.get("raw", text)
         page = section["page"]
 
-        for match in DEFINITION_PATTERN.finditer(text):
-            term = match.group(1).strip()
-            description = match.group(2).strip().split("\n")[0]
+        for term, description, snippet in _definition_candidates(text, raw_text):
+            key = (term.lower(), description.lower())
+            if key in seen_definitions:
+                continue
+            seen_definitions.add(key)
             facts.append(
                 {
                     "kind": "definition",
                     "term": term,
                     "desc": description,
                     "page": page,
-                    "source": text[:400],
+                    "source": snippet,
                 }
             )
 
-        bullet_lines = [
-            line.strip("•- \t")
-            for line in text.splitlines()
-            if line.strip().startswith(("•", "-"))
-        ]
-        if 2 <= len(bullet_lines) <= 8:
-            title = text.splitlines()[0][:80]
+        for title, items, snippet in _list_candidates(text, raw_text, normalized_language):
             facts.append(
                 {
                     "kind": "list",
                     "title": title,
-                    "items": bullet_lines,
+                    "items": items,
                     "page": page,
-                    "source": text[:400],
+                    "source": snippet,
                 }
             )
 
+        summary_fact = _summary_candidate(section, normalized_language)
+        if summary_fact:
+            summary_fact.update({"page": page, "source": raw_text[:400]})
+            facts.append(summary_fact)
+
     return facts
+
+
+def _definition_candidates(text: str, raw_text: str) -> Iterable[tuple[str, str, str]]:
+    snippet = raw_text[:400]
+
+    for match in DEFINITION_PATTERN.finditer(text):
+        term = match.group(1).strip()
+        description = match.group(2).strip().split("\n")[0]
+        if len(term) < 2 or len(description) < 10:
+            continue
+        yield term, description, snippet
+
+    for match in COLON_DEFINITION_PATTERN.finditer(text):
+        term = match.group(1).strip()
+        description = match.group(2).strip()
+        if len(term) < 2 or len(description) < 10:
+            continue
+        yield term, description, snippet
+
+
+def _list_candidates(
+    text: str, raw_text: str, language: str
+) -> Iterable[tuple[str, List[str], str]]:
+    snippet = raw_text[:400]
+
+    bullet_lines = [
+        line.strip("•- \t")
+        for line in text.splitlines()
+        if line.strip().startswith(("•", "-"))
+    ]
+    if 2 <= len(bullet_lines) <= 8:
+        title = _pick_title(text, bullet_lines[0])
+        yield title, _clean_items(bullet_lines), snippet
+
+    numbered_lines = [
+        re.sub(r"^\s*\d+[\.)]\s*", "", line).strip()
+        for line in text.splitlines()
+        if re.match(r"^\s*\d+[\.)]\s+", line)
+    ]
+    if 2 <= len(numbered_lines) <= 8:
+        title = _pick_title(text, numbered_lines[0])
+        yield title, _clean_items(numbered_lines), snippet
+
+    sentences = _split_sentences(text)
+    for sentence in sentences:
+        for pattern in ENUMERATION_PATTERNS:
+            match = pattern.match(sentence)
+            if not match:
+                continue
+            title = match.group(1).strip()
+            raw_items = match.group(2).strip()
+            items = _split_enumeration(raw_items, language)
+            if 2 <= len(items) <= 8:
+                yield title, _clean_items(items), snippet
+
+
+def _summary_candidate(section: Dict[str, str], language: str) -> Dict[str, object] | None:
+    heading = section.get("heading", "").strip()
+    text = section["text"]
+    if not heading or len(heading) < 4:
+        return None
+
+    sentences = [s for s in _split_sentences(text) if len(s) >= 30]
+    if not sentences:
+        return None
+
+    summary = " ".join(sentences[:2]).strip()
+    if len(summary) < 40 or len(summary) > 320:
+        return None
+
+    return {
+        "kind": "summary",
+        "title": heading,
+        "summary": summary,
+        "language": language,
+    }
+
+
+def _split_sentences(text: str) -> List[str]:
+    if not text:
+        return []
+    parts = SENTENCE_SPLIT_PATTERN.split(text)
+    if not parts:
+        return [text.strip()]
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _pick_title(text: str, fallback: str) -> str:
+    first_line = text.splitlines()[0].strip()
+    if len(first_line) > 6 and len(first_line) <= 120:
+        return first_line
+    return fallback[:80]
+
+
+def _split_enumeration(items: str, language: str) -> List[str]:
+    delimiters = [",", ";", " • "]
+    normalized_language = _normalise_language(language)
+    if normalized_language == "fr":
+        delimiters.extend([" et ", " ou "])
+    else:
+        delimiters.extend([" and ", " or "])
+
+    pattern = re.compile("|".join(map(re.escape, delimiters)))
+    return [chunk.strip() for chunk in pattern.split(items) if chunk.strip()]
+
+
+def _clean_items(items: Iterable[str]) -> List[str]:
+    cleaned = []
+    seen = set()
+    for item in items:
+        value = re.sub(r"\s+", " ", item).strip()
+        if not value or value.lower() in seen:
+            continue
+        seen.add(value.lower())
+        cleaned.append(value)
+    return cleaned
+
+
+def _normalise_language(language: str | None) -> str:
+    if not language:
+        return "en"
+    language = language.lower()
+    if language.startswith("fr"):
+        return "fr"
+    if language.startswith("en"):
+        return "en"
+    return "en"

--- a/backend/extractor.py
+++ b/backend/extractor.py
@@ -1,0 +1,48 @@
+import re
+from typing import Dict, List
+
+
+DEFINITION_PATTERN = re.compile(
+    r"(?:Definition[:\-]\s*)?(.{2,60}?)\s+(?:is|are|est|sont)\s+(.{10,250})",
+    flags=re.IGNORECASE,
+)
+
+
+def extract_facts(sections: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    """Identify definition and list facts from section text."""
+    facts: List[Dict[str, object]] = []
+    for section in sections:
+        text = section["text"]
+        page = section["page"]
+
+        for match in DEFINITION_PATTERN.finditer(text):
+            term = match.group(1).strip()
+            description = match.group(2).strip().split("\n")[0]
+            facts.append(
+                {
+                    "kind": "definition",
+                    "term": term,
+                    "desc": description,
+                    "page": page,
+                    "source": text[:400],
+                }
+            )
+
+        bullet_lines = [
+            line.strip("•- \t")
+            for line in text.splitlines()
+            if line.strip().startswith(("•", "-"))
+        ]
+        if 2 <= len(bullet_lines) <= 8:
+            title = text.splitlines()[0][:80]
+            facts.append(
+                {
+                    "kind": "list",
+                    "title": title,
+                    "items": bullet_lines,
+                    "page": page,
+                    "source": text[:400],
+                }
+            )
+
+    return facts

--- a/backend/llm_extractor.py
+++ b/backend/llm_extractor.py
@@ -1,0 +1,258 @@
+"""LLM-driven card extraction with chunked prompts."""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from llm_utils import EXTRACTION_MODEL, OpenAIError, estimate_tokens, get_async_client
+
+
+MAX_CHUNK_TOKENS = int(os.getenv("LLM_MAX_CHUNK_TOKENS", "3200"))
+CHUNK_OVERLAP = int(os.getenv("LLM_CHUNK_OVERLAP_TOKENS", "200"))
+
+
+@dataclass
+class Section:
+    page: int
+    text: str
+
+
+@dataclass
+class Chunk:
+    text: str
+    start_page: int
+    end_page: int
+
+
+async def generate_cards(
+    sections: Sequence[Dict[str, object]],
+    language: str,
+    card_types: Sequence[str],
+    max_cards: int,
+) -> Tuple[List[Dict[str, object]], Dict[str, object]]:
+    """Generate flashcards with an LLM using chunked prompts."""
+
+    client = get_async_client()
+    if client is None:
+        return [], {
+            "used": False,
+            "generated": 0,
+            "chunks": 0,
+            "model": None,
+            "duration_ms": 0,
+            "error": "OpenAI API key not configured on server",
+        }
+
+    normalized = _normalise_sections(sections)
+    if not normalized:
+        return [], {
+            "used": False,
+            "generated": 0,
+            "chunks": 0,
+            "model": EXTRACTION_MODEL,
+            "duration_ms": 0,
+            "error": None,
+        }
+
+    chunks = list(_build_chunks(normalized))
+    cards: List[Dict[str, object]] = []
+    total_duration = 0
+
+    for idx, chunk in enumerate(chunks, start=1):
+        remaining = max_cards - len(cards)
+        if remaining <= 0:
+            break
+
+        prompt = _build_prompt(chunk, language, card_types, remaining)
+        chunk_start = time.perf_counter()
+        try:
+            response = await client.chat.completions.create(  # type: ignore[union-attr]
+                model=EXTRACTION_MODEL,
+                temperature=0.1,
+                response_format={"type": "json_object"},
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You analyse textbook excerpts and produce factual Anki flashcards"
+                            " in the requested language. Only quote information explicitly"
+                            " present in the text."
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            )
+        except OpenAIError as exc:  # pragma: no cover - depends on network
+            return cards, {
+                "used": True,
+                "generated": len(cards),
+                "chunks": idx,
+                "model": EXTRACTION_MODEL,
+                "duration_ms": int(total_duration * 1000),
+                "error": str(exc),
+            }
+
+        chunk_duration = time.perf_counter() - chunk_start
+        total_duration += chunk_duration
+        message = response.choices[0].message.content if response.choices else ""
+        cards.extend(_parse_cards(message, chunk, card_types, remaining))
+
+    cards = cards[:max_cards]
+    return cards, {
+        "used": True,
+        "generated": len(cards),
+        "chunks": len(chunks),
+        "model": EXTRACTION_MODEL,
+        "duration_ms": int(total_duration * 1000),
+        "error": None,
+    }
+
+
+def _normalise_sections(sections: Sequence[Dict[str, object]]) -> List[Section]:
+    normalised: List[Section] = []
+    for entry in sections:
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        page_raw = entry.get("page", 1)
+        try:
+            page = int(page_raw)
+        except (TypeError, ValueError):
+            page = 1
+        normalised.append(Section(page=page, text=text))
+    return normalised
+
+
+def _build_chunks(sections: Sequence[Section]) -> Iterable[Chunk]:
+    if not sections:
+        return []
+
+    buffer: List[Section] = []
+    current_tokens = 0
+
+    for section in sections:
+        tokens = estimate_tokens(section.text)
+        if buffer and current_tokens + tokens > MAX_CHUNK_TOKENS:
+            yield Chunk(
+                text="\n\n".join(item.text for item in buffer),
+                start_page=buffer[0].page,
+                end_page=buffer[-1].page,
+            )
+            if CHUNK_OVERLAP > 0 and buffer:
+                overlap: List[Section] = []
+                overlap_tokens = 0
+                for previous in reversed(buffer):
+                    overlap.insert(0, previous)
+                    overlap_tokens += estimate_tokens(previous.text)
+                    if overlap_tokens >= CHUNK_OVERLAP:
+                        break
+                buffer = overlap + [section]
+            else:
+                buffer = [section]
+            current_tokens = sum(estimate_tokens(item.text) for item in buffer)
+        else:
+            buffer.append(section)
+            current_tokens += tokens
+
+    if buffer:
+        yield Chunk(
+            text="\n\n".join(item.text for item in buffer),
+            start_page=buffer[0].page,
+            end_page=buffer[-1].page,
+        )
+
+
+def _build_prompt(
+    chunk: Chunk, language: str, card_types: Sequence[str], remaining: int
+) -> str:
+    card_list = ", ".join(card_types) if card_types else "qa"
+    instructions = (
+        "Analyse the following PDF excerpt spanning pages "
+        f"{chunk.start_page} to {chunk.end_page}. "
+        f"Create up to {remaining} concise Anki cards in JSON format. "
+        f"Only produce the supported card types: {card_list}. "
+        "Each card must be grounded in the excerpt and include the page number "
+        "and a short source snippet to justify the answer."
+    )
+    schema = (
+        "Return JSON like:\n"
+        "{\n  \"cards\": [\n    {\n      \"type\": \"qa|cloze\",\n"
+        "      \"question\": str,\n      \"answer\": str,\n      \"tags\": [str],\n"
+        "      \"explanation\": Optional[str],\n      \"source_page\": int,\n"
+        "      \"source_snippet\": str,\n      \"confidence\": Optional[float]\n"
+        "    }\n  ]\n}\n"
+        "If the excerpt lacks enough information, return an empty list."
+    )
+    prompt = (
+        f"Language: {language}\n"
+        f"Supported card types: {card_list}\n"
+        f"Maximum cards for this chunk: {remaining}\n"
+        f"Excerpt:\n{chunk.text}"
+    )
+    return instructions + "\n\n" + schema + "\n\n" + prompt
+
+
+def _parse_cards(
+    message: Optional[str],
+    chunk: Chunk,
+    allowed_types: Sequence[str],
+    remaining: int,
+) -> List[Dict[str, object]]:
+    if not message:
+        return []
+    try:
+        payload = json.loads(message)
+    except json.JSONDecodeError:
+        return []
+
+    results: List[Dict[str, object]] = []
+    for entry in payload.get("cards", []):
+        if len(results) >= remaining:
+            break
+        card_type = entry.get("type", "qa")
+        if card_type not in allowed_types:
+            continue
+        question = entry.get("question")
+        answer = entry.get("answer", "")
+        if not isinstance(question, str) or not question.strip():
+            continue
+        if not isinstance(answer, str):
+            answer = ""
+        tags = entry.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+        source_page = entry.get("source_page", chunk.start_page)
+        try:
+            page = int(source_page)
+        except (TypeError, ValueError):
+            page = chunk.start_page
+        snippet = entry.get("source_snippet")
+        if not isinstance(snippet, str) or not snippet.strip():
+            snippet = chunk.text[:400]
+        confidence = entry.get("confidence")
+        try:
+            confidence_value = float(confidence) if confidence is not None else 0.7
+        except (TypeError, ValueError):
+            confidence_value = 0.7
+        explanation = entry.get("explanation")
+        if explanation is not None and not isinstance(explanation, str):
+            explanation = None
+        results.append(
+            {
+                "id": uuid.uuid4().hex[:12],
+                "type": card_type,
+                "question": question.strip(),
+                "answer": answer.strip(),
+                "tags": [t for t in tags if isinstance(t, str) and t],
+                "source_page": page,
+                "source_snippet": snippet.strip(),
+                "confidence": max(0.3, min(1.0, confidence_value)),
+                "explanation": explanation.strip() if isinstance(explanation, str) else None,
+            }
+        )
+    return results
+

--- a/backend/llm_refiner.py
+++ b/backend/llm_refiner.py
@@ -6,28 +6,10 @@ import os
 import time
 from typing import Dict, List, Optional, Tuple
 
-try:  # Optional dependency
-    from openai import AsyncOpenAI
-    from openai import OpenAIError
-except Exception:  # pragma: no cover - library may be missing during tests
-    AsyncOpenAI = None  # type: ignore
-    OpenAIError = Exception  # type: ignore
+from llm_utils import OpenAIError, REFINEMENT_MODEL, get_async_client
 
 
-DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 MAX_CARDS = int(os.getenv("LLM_REFINEMENT_LIMIT", "15"))
-
-_client: Optional[AsyncOpenAI] = None
-
-
-def _get_client() -> Optional[AsyncOpenAI]:
-    global _client
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or AsyncOpenAI is None:
-        return None
-    if _client is None:
-        _client = AsyncOpenAI(api_key=api_key)
-    return _client
 
 
 async def refine_cards(
@@ -35,7 +17,7 @@ async def refine_cards(
 ) -> Tuple[List[Dict[str, object]], Dict[str, object]]:
     """Use an LLM to polish questions/answers when credentials are configured."""
 
-    client = _get_client()
+    client = get_async_client()
     if client is None or not cards:
         return cards, {
             "used": False,
@@ -51,7 +33,7 @@ async def refine_cards(
     start = time.perf_counter()
     try:
         response = await client.chat.completions.create(  # type: ignore[union-attr]
-            model=DEFAULT_MODEL,
+            model=REFINEMENT_MODEL,
             temperature=0.2,
             response_format={"type": "json_object"},
             messages=[
@@ -73,7 +55,7 @@ async def refine_cards(
         return cards, {
             "used": True,
             "enriched": 0,
-            "model": DEFAULT_MODEL,
+            "model": REFINEMENT_MODEL,
             "duration_ms": int((time.perf_counter() - start) * 1000),
             "error": str(exc),
         }
@@ -107,7 +89,7 @@ async def refine_cards(
     return cards, {
         "used": True,
         "enriched": enriched,
-        "model": getattr(response, "model", DEFAULT_MODEL),
+        "model": getattr(response, "model", REFINEMENT_MODEL),
         "duration_ms": duration_ms,
         "error": None,
     }

--- a/backend/llm_refiner.py
+++ b/backend/llm_refiner.py
@@ -1,0 +1,164 @@
+"""Optional LLM-powered refinement of generated cards."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Dict, List, Optional, Tuple
+
+try:  # Optional dependency
+    from openai import AsyncOpenAI
+    from openai import OpenAIError
+except Exception:  # pragma: no cover - library may be missing during tests
+    AsyncOpenAI = None  # type: ignore
+    OpenAIError = Exception  # type: ignore
+
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+MAX_CARDS = int(os.getenv("LLM_REFINEMENT_LIMIT", "15"))
+
+_client: Optional[AsyncOpenAI] = None
+
+
+def _get_client() -> Optional[AsyncOpenAI]:
+    global _client
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or AsyncOpenAI is None:
+        return None
+    if _client is None:
+        _client = AsyncOpenAI(api_key=api_key)
+    return _client
+
+
+async def refine_cards(
+    cards: List[Dict[str, object]], language: str | None
+) -> Tuple[List[Dict[str, object]], Dict[str, object]]:
+    """Use an LLM to polish questions/answers when credentials are configured."""
+
+    client = _get_client()
+    if client is None or not cards:
+        return cards, {
+            "used": False,
+            "enriched": 0,
+            "model": None,
+            "duration_ms": 0,
+            "error": None,
+        }
+
+    subset = cards[:MAX_CARDS]
+    prompt = _build_prompt(subset, language or "en")
+
+    start = time.perf_counter()
+    try:
+        response = await client.chat.completions.create(  # type: ignore[union-attr]
+            model=DEFAULT_MODEL,
+            temperature=0.2,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You rewrite flashcards so that they stay factual, concise, and"
+                        " faithful to the provided PDF excerpts. Return polished cards"
+                        " in JSON and never invent facts beyond the supplied source."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        )
+    except OpenAIError as exc:  # pragma: no cover - depends on network
+        return cards, {
+            "used": True,
+            "enriched": 0,
+            "model": DEFAULT_MODEL,
+            "duration_ms": int((time.perf_counter() - start) * 1000),
+            "error": str(exc),
+        }
+
+    duration_ms = int((time.perf_counter() - start) * 1000)
+    message = response.choices[0].message.content if response.choices else ""
+    updates = _parse_updates(message)
+
+    enriched = 0
+    for card in subset:
+        update = updates.get(card["id"], {})
+        if not update:
+            continue
+        enriched += 1
+        if "question" in update and isinstance(update["question"], str):
+            card["question"] = update["question"].strip()
+        if "answer" in update and isinstance(update["answer"], str):
+            card["answer"] = update["answer"].strip()
+        if "explanation" in update and isinstance(update["explanation"], str):
+            card["explanation"] = update["explanation"].strip()
+        if "tags" in update and isinstance(update["tags"], list):
+            merged_tags = list({*card.get("tags", []), *update["tags"]})
+            card["tags"] = sorted(filter(None, merged_tags))
+        if "confidence" in update:
+            try:
+                value = float(update["confidence"])
+            except (TypeError, ValueError):
+                value = card.get("confidence", 0.7)
+            card["confidence"] = max(0.3, min(1.0, value))
+
+    return cards, {
+        "used": True,
+        "enriched": enriched,
+        "model": getattr(response, "model", DEFAULT_MODEL),
+        "duration_ms": duration_ms,
+        "error": None,
+    }
+
+
+def _build_prompt(cards: List[Dict[str, object]], language: str) -> str:
+    payload = {
+        "language": language,
+        "cards": [
+            {
+                "id": card["id"],
+                "type": card["type"],
+                "question": card["question"],
+                "answer": card["answer"],
+                "tags": card.get("tags", []),
+                "source_snippet": card.get("source_snippet", ""),
+            }
+            for card in cards
+        ],
+    }
+    instructions = (
+        "Polish each card so that it reads naturally in the requested language,"
+        " keeps one atomic fact, and cites only details from the source snippet."
+        " Provide an optional short explanation summarising why the answer matters."
+        " Output JSON with this shape: {\n"
+        "  \"cards\": [\n"
+        "    {\n"
+        "      \"id\": str,\n"
+        "      \"question\": str,\n"
+        "      \"answer\": str,\n"
+        "      \"tags\": [str],\n"
+        "      \"explanation\": Optional[str],\n"
+        "      \"confidence\": Optional[float]\n"
+        "    }\n"
+        "  ]\n"
+        "}."
+    )
+    return instructions + "\n\n" + json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _parse_updates(message: Optional[str]) -> Dict[str, Dict[str, object]]:
+    if not message:
+        return {}
+    try:
+        data = json.loads(message)
+    except json.JSONDecodeError:
+        return {}
+    updates: Dict[str, Dict[str, object]] = {}
+    for entry in data.get("cards", []):
+        card_id = entry.get("id")
+        if not isinstance(card_id, str):
+            continue
+        updates[card_id] = entry
+    return updates

--- a/backend/llm_utils.py
+++ b/backend/llm_utils.py
@@ -1,0 +1,51 @@
+"""Shared helpers for working with the OpenAI async client."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency during tests
+    from openai import AsyncOpenAI
+    from openai import OpenAIError
+except Exception:  # pragma: no cover
+    AsyncOpenAI = None  # type: ignore
+    OpenAIError = Exception  # type: ignore
+
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+EXTRACTION_MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", DEFAULT_MODEL)
+REFINEMENT_MODEL = os.getenv("OPENAI_REFINEMENT_MODEL", DEFAULT_MODEL)
+
+
+@lru_cache(maxsize=1)
+def _client_factory() -> Optional[AsyncOpenAI]:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or AsyncOpenAI is None:
+        return None
+    return AsyncOpenAI(api_key=api_key)
+
+
+def get_async_client() -> Optional[AsyncOpenAI]:
+    """Return a cached AsyncOpenAI client when credentials are configured."""
+
+    return _client_factory()
+
+
+def estimate_tokens(text: str) -> int:
+    """Very rough heuristic to estimate token usage for chunking."""
+
+    # Average English token ≈ 4 characters; clamp to positive integers.
+    return max(1, len(text) // 4)
+
+
+__all__ = [
+    "AsyncOpenAI",
+    "OpenAIError",
+    "DEFAULT_MODEL",
+    "EXTRACTION_MODEL",
+    "REFINEMENT_MODEL",
+    "get_async_client",
+    "estimate_tokens",
+]
+

--- a/backend/models.py
+++ b/backend/models.py
@@ -27,9 +27,12 @@ class Card(BaseModel):
 
 class LLMReport(BaseModel):
     used: bool
+    generated: int = 0
     enriched: int = 0
     model: Optional[str] = None
     duration_ms: int = 0
+    chunks: int = 0
+    mode: Literal["extraction", "refinement"] = "extraction"
     error: Optional[str] = None
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,33 @@
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel
+
+CardType = Literal["qa", "cloze"]
+
+
+class ExtractRequest(BaseModel):
+    filename: str
+    language: Optional[str] = "en"
+    card_types: List[CardType] = ["qa", "cloze"]
+    max_cards: int = 100
+
+
+class Card(BaseModel):
+    id: str
+    type: CardType
+    question: str
+    answer: str
+    tags: List[str] = []
+    source_page: int
+    confidence: float
+    source_snippet: str
+
+
+class ExtractResponse(BaseModel):
+    cards: List[Card]
+    metrics: Dict[str, int]
+
+
+class ExportRequest(BaseModel):
+    deck_name: str
+    cards: List[Card]

--- a/backend/models.py
+++ b/backend/models.py
@@ -10,6 +10,7 @@ class ExtractRequest(BaseModel):
     language: Optional[str] = "en"
     card_types: List[CardType] = ["qa", "cloze"]
     max_cards: int = 100
+    use_llm: bool = True
 
 
 class Card(BaseModel):
@@ -21,11 +22,21 @@ class Card(BaseModel):
     source_page: int
     confidence: float
     source_snippet: str
+    explanation: Optional[str] = None
+
+
+class LLMReport(BaseModel):
+    used: bool
+    enriched: int = 0
+    model: Optional[str] = None
+    duration_ms: int = 0
+    error: Optional[str] = None
 
 
 class ExtractResponse(BaseModel):
     cards: List[Card]
-    metrics: Dict[str, int]
+    metrics: Dict[str, float]
+    llm: Optional[LLMReport] = None
 
 
 class ExportRequest(BaseModel):

--- a/backend/pdf_reader.py
+++ b/backend/pdf_reader.py
@@ -1,0 +1,13 @@
+from typing import List
+
+import fitz  # PyMuPDF
+
+
+def read_pdf(buf: bytes) -> List[str]:
+    """Return plain text for each page of the PDF buffer."""
+    doc = fitz.open(stream=buf, filetype="pdf")
+    pages: List[str] = []
+    for page in doc:
+        text = page.get_text("text")
+        pages.append(text)
+    return pages

--- a/backend/quality.py
+++ b/backend/quality.py
@@ -1,0 +1,25 @@
+import hashlib
+from typing import Dict, List
+
+
+def apply_checks(cards: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    """Deduplicate and enforce length constraints on generated cards."""
+    seen_hashes = set()
+    filtered: List[Dict[str, object]] = []
+
+    for card in cards:
+        fingerprint = hashlib.sha1(
+            (card["type"] + card["question"] + card["answer"]).encode()
+        ).hexdigest()
+        if fingerprint in seen_hashes:
+            continue
+        seen_hashes.add(fingerprint)
+
+        if len(card["question"]) > 240:
+            card["question"] = card["question"][:240] + "…"
+        if len(card["answer"]) > 280:
+            card["answer"] = card["answer"][:280] + "…"
+
+        filtered.append(card)
+
+    return filtered

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 pymupdf
 pytesseract
+python-multipart
 pillow
 pandas
 regex

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pillow
 pandas
 regex
 genanki
+openai>=1.40.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+pymupdf
+pytesseract
+pillow
+pandas
+regex
+genanki

--- a/backend/segmenter.py
+++ b/backend/segmenter.py
@@ -9,7 +9,7 @@ HEADING_PATTERN = re.compile(
 
 
 def split_into_sections(text_by_page: List[str]) -> List[Dict[str, str]]:
-    """Split raw page texts into moderately-sized sections."""
+    """Split raw page texts into moderately-sized sections with optional headings."""
     sections: List[Dict[str, str]] = []
     for index, page_text in enumerate(text_by_page, start=1):
         parts = re.split(HEADING_PATTERN, page_text)
@@ -17,5 +17,24 @@ def split_into_sections(text_by_page: List[str]) -> List[Dict[str, str]]:
             chunk = chunk.strip()
             if len(chunk) <= 40:
                 continue
-            sections.append({"page": index, "text": chunk})
+
+            lines = [line.strip() for line in chunk.splitlines() if line.strip()]
+            if not lines:
+                continue
+
+            heading = lines[0]
+            body_lines = lines[1:]
+            body = "\n".join(body_lines).strip()
+
+            if not body:
+                body = chunk
+
+            sections.append(
+                {
+                    "page": index,
+                    "text": body,
+                    "heading": heading,
+                    "raw": chunk,
+                }
+            )
     return sections

--- a/backend/segmenter.py
+++ b/backend/segmenter.py
@@ -1,0 +1,21 @@
+import re
+from typing import Dict, List
+
+
+HEADING_PATTERN = re.compile(
+    r"\n(?=[A-Z][A-Z \-]{3,}$|\w[^.\n]{0,40}:\s?$)",
+    flags=re.MULTILINE,
+)
+
+
+def split_into_sections(text_by_page: List[str]) -> List[Dict[str, str]]:
+    """Split raw page texts into moderately-sized sections."""
+    sections: List[Dict[str, str]] = []
+    for index, page_text in enumerate(text_by_page, start=1):
+        parts = re.split(HEADING_PATTERN, page_text)
+        for chunk in parts:
+            chunk = chunk.strip()
+            if len(chunk) <= 40:
+                continue
+            sections.append({"page": index, "text": chunk})
+    return sections

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF → Anki</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pdf2anki-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@tailwindcss/typography": "^0.5.10",
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,9 +15,9 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitejs/plugin-vue": "^4.5.0",
     "@tailwindcss/typography": "^0.5.10",
     "tailwindcss": "^3.4.0",
-    "vite": "^5.0.0"
+    "vite": "^4.5.0"
   }
 }

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,7 +104,7 @@ async function exportApkg() {
       </select>
       <label class="flex items-center gap-2 text-sm">
         <input type="checkbox" v-model="useLLM" />
-        Enhance with AI
+        Generate with AI (LLM)
       </label>
       <button
         class="px-3 py-1 rounded bg-emerald-600 text-white disabled:opacity-40"
@@ -116,15 +116,22 @@ async function exportApkg() {
     </section>
 
     <section v-if="llmReport" class="text-sm text-gray-600 space-y-1">
-      <p v-if="llmReport.used">
-        AI refined {{ llmReport.enriched }} cards in
-        {{ (llmReport.duration_ms / 1000).toFixed(2) }}s.
-      </p>
-      <p v-else>AI refinement skipped (no API key configured on the server).</p>
+      <template v-if="llmReport.used">
+        <p>
+          AI generated {{ llmReport.generated }} cards across
+          {{ llmReport.chunks || 1 }} chunk{{ llmReport.chunks === 1 ? '' : 's' }} in
+          {{ (llmReport.duration_ms / 1000).toFixed(2) }}s.
+        </p>
+      </template>
+      <template v-else>
+        <p v-if="llmReport.error" class="text-red-600">
+          AI extraction unavailable: {{ llmReport.error }}
+        </p>
+        <p v-else>AI extraction skipped.</p>
+      </template>
       <p v-if="llmReport.model" class="text-xs text-gray-500">
         Model: {{ llmReport.model }}
       </p>
-      <p v-if="llmReport.error" class="text-red-600">{{ llmReport.error }}</p>
     </section>
 
     <section class="grid gap-4 md:grid-cols-2">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,21 @@
 <script setup>
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import axios from 'axios'
 
 const pdfId = ref('')
 const cards = ref([])
 const metrics = ref(null)
 const deckName = ref('Demo Deck')
+const language = ref('en')
+
+onMounted(() => {
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    const locale = navigator.language.toLowerCase()
+    if (locale.startsWith('fr')) {
+      language.value = 'fr'
+    }
+  }
+})
 
 async function uploadPDF(event) {
   const file = event.target.files?.[0]
@@ -20,7 +30,7 @@ async function extract() {
   if (!pdfId.value) return
   const body = {
     filename: 'uploaded.pdf',
-    language: 'en',
+    language: language.value,
     card_types: ['qa', 'cloze'],
     max_cards: 50
   }
@@ -75,9 +85,14 @@ async function exportApkg() {
       Pages: {{ metrics.pages }} — Candidates: {{ metrics.candidates }}
     </section>
 
-    <section class="flex items-center gap-3">
+    <section class="flex flex-wrap items-center gap-3">
       <label class="text-sm">Deck name</label>
       <input v-model="deckName" class="border rounded px-2 py-1" />
+      <label class="text-sm">Language</label>
+      <select v-model="language" class="border rounded px-2 py-1">
+        <option value="en">English</option>
+        <option value="fr">Français</option>
+      </select>
       <button
         class="px-3 py-1 rounded bg-emerald-600 text-white disabled:opacity-40"
         :disabled="!cards.length"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,13 @@ const cards = ref([])
 const metrics = ref(null)
 const deckName = ref('Demo Deck')
 const language = ref('en')
+const useLLM = ref(true)
+const llmReport = ref(null)
+
+const formatMetric = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return value
+  return Number.isInteger(value) ? value : value.toFixed(2)
+}
 
 onMounted(() => {
   if (typeof navigator !== 'undefined' && navigator.language) {
@@ -32,11 +39,13 @@ async function extract() {
     filename: 'uploaded.pdf',
     language: language.value,
     card_types: ['qa', 'cloze'],
-    max_cards: 50
+    max_cards: 50,
+    use_llm: useLLM.value
   }
   const { data } = await axios.post(`/api/extract?pdf_id=${pdfId.value}`, body)
   cards.value = data.cards
   metrics.value = data.metrics
+  llmReport.value = data.llm
 }
 
 async function exportApkg() {
@@ -82,7 +91,7 @@ async function exportApkg() {
     </section>
 
     <section v-if="metrics" class="text-sm text-gray-600">
-      Pages: {{ metrics.pages }} — Candidates: {{ metrics.candidates }}
+      Pages: {{ formatMetric(metrics.pages) }} — Candidates: {{ formatMetric(metrics.candidates) }}
     </section>
 
     <section class="flex flex-wrap items-center gap-3">
@@ -93,6 +102,10 @@ async function exportApkg() {
         <option value="en">English</option>
         <option value="fr">Français</option>
       </select>
+      <label class="flex items-center gap-2 text-sm">
+        <input type="checkbox" v-model="useLLM" />
+        Enhance with AI
+      </label>
       <button
         class="px-3 py-1 rounded bg-emerald-600 text-white disabled:opacity-40"
         :disabled="!cards.length"
@@ -100,6 +113,18 @@ async function exportApkg() {
       >
         Export .apkg
       </button>
+    </section>
+
+    <section v-if="llmReport" class="text-sm text-gray-600 space-y-1">
+      <p v-if="llmReport.used">
+        AI refined {{ llmReport.enriched }} cards in
+        {{ (llmReport.duration_ms / 1000).toFixed(2) }}s.
+      </p>
+      <p v-else>AI refinement skipped (no API key configured on the server).</p>
+      <p v-if="llmReport.model" class="text-xs text-gray-500">
+        Model: {{ llmReport.model }}
+      </p>
+      <p v-if="llmReport.error" class="text-red-600">{{ llmReport.error }}</p>
     </section>
 
     <section class="grid gap-4 md:grid-cols-2">
@@ -111,6 +136,9 @@ async function exportApkg() {
         <div class="prose" v-html="card.question"></div>
         <p v-if="card.answer" class="text-gray-800">{{ card.answer }}</p>
         <p class="text-xs text-gray-500 max-h-16 overflow-hidden">{{ card.source_snippet }}</p>
+        <p v-if="card.explanation" class="text-xs text-amber-600">
+          {{ card.explanation }}
+        </p>
         <div class="flex flex-wrap gap-2">
           <span
             v-for="tag in card.tags"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,111 @@
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+
+const pdfId = ref('')
+const cards = ref([])
+const metrics = ref(null)
+const deckName = ref('Demo Deck')
+
+async function uploadPDF(event) {
+  const file = event.target.files?.[0]
+  if (!file) return
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await axios.post('/api/upload', form)
+  pdfId.value = data.pdf_id
+}
+
+async function extract() {
+  if (!pdfId.value) return
+  const body = {
+    filename: 'uploaded.pdf',
+    language: 'en',
+    card_types: ['qa', 'cloze'],
+    max_cards: 50
+  }
+  const { data } = await axios.post(`/api/extract?pdf_id=${pdfId.value}`, body)
+  cards.value = data.cards
+  metrics.value = data.metrics
+}
+
+async function exportApkg() {
+  if (!cards.value.length) return
+  const { data } = await axios.post(
+    '/api/export.apkg',
+    { deck_name: deckName.value, cards: cards.value },
+    { responseType: 'blob' }
+  )
+  const url = URL.createObjectURL(new Blob([data]))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `${deckName.value}.apkg`
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<template>
+  <div class="max-w-5xl mx-auto p-6 space-y-6">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold">PDF → Anki Cards</h1>
+      <p class="text-gray-600">
+        Upload your course PDF, generate candidate cards, review them, then export directly to
+        Anki.
+      </p>
+    </header>
+
+    <section class="flex flex-wrap items-center gap-4">
+      <input
+        type="file"
+        accept="application/pdf"
+        @change="uploadPDF"
+        class="block"
+      />
+      <button
+        class="px-4 py-2 rounded bg-black text-white disabled:opacity-40"
+        :disabled="!pdfId"
+        @click="extract"
+      >
+        Extract
+      </button>
+    </section>
+
+    <section v-if="metrics" class="text-sm text-gray-600">
+      Pages: {{ metrics.pages }} — Candidates: {{ metrics.candidates }}
+    </section>
+
+    <section class="flex items-center gap-3">
+      <label class="text-sm">Deck name</label>
+      <input v-model="deckName" class="border rounded px-2 py-1" />
+      <button
+        class="px-3 py-1 rounded bg-emerald-600 text-white disabled:opacity-40"
+        :disabled="!cards.length"
+        @click="exportApkg"
+      >
+        Export .apkg
+      </button>
+    </section>
+
+    <section class="grid gap-4 md:grid-cols-2">
+      <article v-for="card in cards" :key="card.id" class="p-4 border rounded space-y-2">
+        <div class="text-xs uppercase text-gray-500">
+          {{ card.type.toUpperCase() }} — p.{{ card.source_page }} — conf
+          {{ Math.round(card.confidence * 100) }}%
+        </div>
+        <div class="prose" v-html="card.question"></div>
+        <p v-if="card.answer" class="text-gray-800">{{ card.answer }}</p>
+        <p class="text-xs text-gray-500 max-h-16 overflow-hidden">{{ card.source_snippet }}</p>
+        <div class="flex flex-wrap gap-2">
+          <span
+            v-for="tag in card.tags"
+            :key="tag"
+            class="text-xs bg-gray-100 rounded px-2 py-0.5"
+          >
+            {{ tag }}
+          </span>
+        </div>
+      </article>
+    </section>
+  </div>
+</template>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,9 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+
+import App from './App.vue'
+import './index.css'
+
+const app = createApp(App)
+app.use(createPinia())
+app.mount('#app')

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,js,ts}'],
+  theme: {
+    extend: {}
+  },
+  plugins: [require('@tailwindcss/typography')]
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, '')
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend that ingests PDFs, extracts sections, generates cards, and exports Anki decks
- add a Vue 3 + Tailwind frontend for uploading PDFs, previewing generated cards, and downloading .apkg files
- document setup steps and add repository ignores for common artifacts

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68da6248ad0c8328b46d48dc5550b178