### PR TITLE
Add FastAPI backend and Vue frontend for PDF to Anki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+*.eggs/
+.python-version
+backend/.venv/
+
+# Node
+node_modules/
+frontend/node_modules/
+frontend/dist/
+
+# Mac/OS
+.DS_Store
+
+# Env
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# pdf2anki
-Give me a pdf document, I will create for you an anki deck to help you with your revision
+# PDF2Anki
+
+Application web complète pour transformer rapidement un fichier PDF en deck Anki prêt à l'emploi.
+
+## Structure du projet
+
+- `backend/` — API FastAPI. Elle reçoit un fichier PDF, extrait le texte, génère des cartes et construit un fichier `.apkg` à télécharger.
+- `frontend/` — Interface Vue 3 avec Vite offrant une expérience moderne de dépôt de fichier.
+
+## Démarrage rapide
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+uvicorn app.main:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+L'interface de développement du frontend proxy automatiquement les requêtes `/api` vers `http://localhost:8000`.
+
+## Tests
+
+```bash
+cd backend
+pytest
+```
+
+## Génération d'un deck
+
+1. Ouvrez l'interface web.
+2. Glissez-déposez ou sélectionnez votre PDF.
+3. Cliquez sur « Générer le deck ».
+4. Téléchargez le fichier `.apkg` proposé et importez-le dans Anki.
+
+Les cartes sont générées via une heuristique simple qui détecte les structures « terme : définition » et scinde les paragraphes en question/réponse.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Application web complète pour transformer rapidement un fichier PDF en deck Anki prêt à l'emploi.
 
+> ℹ️ Depuis cette version, la génération de cartes tente d'utiliser l'API ChatGPT. Si aucune clé OpenAI n'est disponible, une heuristique locale de secours est appliquée.
+
 ## Structure du projet
 
 - `backend/` — API FastAPI. Elle reçoit un fichier PDF, extrait le texte, génère des cartes et construit un fichier `.apkg` à télécharger.
@@ -16,6 +18,8 @@ cd backend
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements-dev.txt
+export OPENAI_API_KEY="votre_cle"
+# optionnel : export OPENAI_MODEL="gpt-4o-mini"
 uvicorn app.main:app --reload
 ```
 
@@ -28,6 +32,8 @@ npm run dev
 ```
 
 L'interface de développement du frontend proxy automatiquement les requêtes `/api` vers `http://localhost:8000`.
+
+> 💡 Les dépendances front-end ciblent désormais Vite 4, compatible avec Node.js 16+ pour éviter les erreurs `crypto.getRandomValues` observées avec Node 16.
 
 ## Tests
 
@@ -43,4 +49,4 @@ pytest
 3. Cliquez sur « Générer le deck ».
 4. Téléchargez le fichier `.apkg` proposé et importez-le dans Anki.
 
-Les cartes sont générées via une heuristique simple qui détecte les structures « terme : définition » et scinde les paragraphes en question/réponse.
+Les cartes sont générées via l'API ChatGPT lorsqu'une clé `OPENAI_API_KEY` est configurée. En cas d'échec ou d'absence de clé, le système retombe sur une heuristique locale détectant les structures « terme : définition » et scindant les paragraphes en question/réponse.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ pytest
 5. Téléchargez le fichier `.apkg` fourni et importez-le dans Anki.
 
 Les cartes sont générées via l'API ChatGPT lorsqu'une clé `OPENAI_API_KEY` est configurée. En cas d'échec ou d'absence de clé, le système retombe sur une heuristique locale détectant les structures « terme : définition » et scindant les paragraphes en question/réponse.
+
+> ✅ Une étape de nettoyage supprime automatiquement les consignes méthodologiques ou les entrées sans contenu factuel afin de ne conserver que les connaissances utiles pour vos révisions.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Application web complète pour transformer rapidement un fichier PDF en deck Ank
 
 ## Structure du projet
 
-- `backend/` — API FastAPI. Elle reçoit un fichier PDF, extrait le texte, génère des cartes et construit un fichier `.apkg` à télécharger.
+- `backend/` — API FastAPI. Elle reçoit un fichier PDF, extrait le texte, génère des cartes, renvoie leur prévisualisation et construit un fichier `.apkg` encodé en Base64 pour téléchargement.
 - `frontend/` — Interface Vue 3 avec Vite offrant une expérience moderne de dépôt de fichier.
 
 ## Démarrage rapide
@@ -47,6 +47,7 @@ pytest
 1. Ouvrez l'interface web.
 2. Glissez-déposez ou sélectionnez votre PDF.
 3. Cliquez sur « Générer le deck ».
-4. Téléchargez le fichier `.apkg` proposé et importez-le dans Anki.
+4. Passez en revue la prévisualisation des cartes proposées.
+5. Téléchargez le fichier `.apkg` fourni et importez-le dans Anki.
 
 Les cartes sont générées via l'API ChatGPT lorsqu'une clé `OPENAI_API_KEY` est configurée. En cas d'échec ou d'absence de clé, le système retombe sur une heuristique locale détectant les structures « terme : définition » et scindant les paragraphes en question/réponse.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package marker for tests."""

--- a/backend/app/flashcards.py
+++ b/backend/app/flashcards.py
@@ -1,6 +1,8 @@
 """Utilities for extracting text from PDFs and building flashcards."""
 from __future__ import annotations
 
+import json
+import os
 import re
 import tempfile
 from dataclasses import dataclass
@@ -9,6 +11,11 @@ from typing import Iterable, List
 
 import genanki
 from PyPDF2 import PdfReader
+
+try:  # pragma: no cover - optional dependency during import time
+    from openai import OpenAI
+except Exception:  # pragma: no cover - allow running without the package installed
+    OpenAI = None  # type: ignore
 
 
 @dataclass
@@ -75,13 +82,24 @@ def _summarize_paragraph(paragraph: str) -> Flashcard | None:
     return Flashcard(front=front, back=back)
 
 
-def build_flashcards_from_text(text: str) -> List[Flashcard]:
-    """Generate flashcards from extracted text.
+def _clean_cards(cards: Iterable[Flashcard]) -> List[Flashcard]:
+    seen = set()
+    unique_cards: List[Flashcard] = []
+    for card in cards:
+        key = (card.front.strip(), card.back.strip())
+        if not card.front.strip() or not card.back.strip():
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_cards.append(
+            Flashcard(front=card.front.strip(), back=card.back.strip())
+        )
+    return unique_cards
 
-    The heuristic is intentionally simple: we prioritise "term: definition"
-    patterns and fall back to splitting longer paragraphs into a lead
-    sentence (front) and supporting sentences (back).
-    """
+
+def build_flashcards_with_heuristics(text: str) -> List[Flashcard]:
+    """Generate flashcards using local heuristics as a fallback."""
 
     paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
     cards: List[Flashcard] = []
@@ -96,16 +114,84 @@ def build_flashcards_from_text(text: str) -> List[Flashcard]:
         if summarized:
             cards.append(summarized)
 
-    # Déduplication basique en gardant l'ordre d'apparition.
-    seen = set()
-    unique_cards: List[Flashcard] = []
-    for card in cards:
-        key = (card.front, card.back)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique_cards.append(card)
-    return unique_cards
+    return _clean_cards(cards)
+
+
+def _call_chatgpt_for_cards(text: str, max_cards: int = 40) -> List[Flashcard]:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise FlashcardGenerationError(
+            "Aucune clé OpenAI détectée. Définissez OPENAI_API_KEY pour activer la génération."
+        )
+
+    if OpenAI is None:  # pragma: no cover - executed only when package missing
+        raise FlashcardGenerationError(
+            "La dépendance 'openai' n'est pas installée."
+        )
+
+    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    client = OpenAI(api_key=api_key)
+
+    # Limiter la taille du prompt afin d'éviter les dépassements de contexte
+    trimmed_text = text.strip()
+    max_chars = int(os.getenv("OPENAI_PROMPT_CHAR_LIMIT", "8000"))
+    if len(trimmed_text) > max_chars:
+        trimmed_text = trimmed_text[:max_chars]
+
+    system_prompt = (
+        "Tu es un expert en pédagogie qui crée des cartes mémoire Anki au format question/réponse. "
+        "Respecte le contenu fourni et réponds en JSON pur."
+    )
+    user_prompt = (
+        "Extrait jusqu'à {max_cards} cartes mémoire pertinentes du texte suivant. "
+        "Réponds uniquement en JSON avec la forme: {{\"flashcards\": [{{\"front\": \"...\", \"back\": \"...\"}}]}}. "
+        "Pas de texte hors JSON.\n\nTexte:\n{texte}"
+    ).format(max_cards=max_cards, texte=trimmed_text)
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            temperature=0.2,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+    except Exception as exc:  # pragma: no cover - network related
+        raise FlashcardGenerationError("La génération via OpenAI a échoué.") from exc
+
+    content = response.choices[0].message.content if response.choices else None
+    if not content:
+        raise FlashcardGenerationError("Réponse vide de l'API OpenAI.")
+
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise FlashcardGenerationError("Réponse OpenAI invalide (JSON attendu).") from exc
+
+    raw_cards = payload.get("flashcards") if isinstance(payload, dict) else payload
+    if not isinstance(raw_cards, list):
+        raise FlashcardGenerationError("Structure JSON inattendue pour les cartes générées.")
+
+    cards = [
+        Flashcard(front=str(entry.get("front", "")), back=str(entry.get("back", "")))
+        for entry in raw_cards
+    ]
+    cleaned = _clean_cards(cards)
+    if not cleaned:
+        raise FlashcardGenerationError("Aucune carte valide renvoyée par OpenAI.")
+    return cleaned
+
+
+def build_flashcards_from_text(text: str) -> List[Flashcard]:
+    """Generate flashcards from extracted text, using ChatGPT when possible."""
+
+    try:
+        cards = _call_chatgpt_for_cards(text)
+    except FlashcardGenerationError:
+        cards = build_flashcards_with_heuristics(text)
+
+    return cards
 
 
 def build_anki_deck(cards: List[Flashcard], title: str) -> str:

--- a/backend/app/flashcards.py
+++ b/backend/app/flashcards.py
@@ -1,0 +1,148 @@
+"""Utilities for extracting text from PDFs and building flashcards."""
+from __future__ import annotations
+
+import re
+import tempfile
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Iterable, List
+
+import genanki
+from PyPDF2 import PdfReader
+
+
+@dataclass
+class Flashcard:
+    """Represents a single flashcard entry."""
+
+    front: str
+    back: str
+
+
+class FlashcardGenerationError(RuntimeError):
+    """Raised when the flashcard generation fails."""
+
+
+def extract_pdf_text(data: bytes) -> str:
+    """Extract all text from a PDF document.
+
+    Args:
+        data: Raw bytes of the PDF file.
+
+    Returns:
+        A single string containing the extracted text.
+
+    Raises:
+        FlashcardGenerationError: If the PDF cannot be read.
+    """
+
+    try:
+        reader = PdfReader(BytesIO(data))
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise FlashcardGenerationError("Le fichier PDF ne peut pas être lu.") from exc
+
+    pieces: List[str] = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        if text:
+            pieces.append(text)
+    return "\n".join(pieces)
+
+
+def _extract_colon_cards(lines: Iterable[str]) -> List[Flashcard]:
+    cards: List[Flashcard] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or ":" not in line:
+            continue
+        if line.count(":") > 3:
+            # Heuristique grossière pour éviter les faux positifs avec les horaires, etc.
+            continue
+        left, right = [part.strip() for part in line.split(":", 1)]
+        if len(left) >= 3 and len(right) >= 3:
+            cards.append(Flashcard(front=left, back=right))
+    return cards
+
+
+def _summarize_paragraph(paragraph: str) -> Flashcard | None:
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", paragraph) if s.strip()]
+    if len(sentences) < 2:
+        return None
+    front = sentences[0]
+    back = "<br>".join(sentences[1:])
+    if len(front) < 10 or len(back) < 10:
+        return None
+    return Flashcard(front=front, back=back)
+
+
+def build_flashcards_from_text(text: str) -> List[Flashcard]:
+    """Generate flashcards from extracted text.
+
+    The heuristic is intentionally simple: we prioritise "term: definition"
+    patterns and fall back to splitting longer paragraphs into a lead
+    sentence (front) and supporting sentences (back).
+    """
+
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    cards: List[Flashcard] = []
+
+    for paragraph in paragraphs:
+        lines = [line.strip() for line in paragraph.splitlines() if line.strip()]
+        colon_cards = _extract_colon_cards(lines)
+        if colon_cards:
+            cards.extend(colon_cards)
+            continue
+        summarized = _summarize_paragraph(paragraph)
+        if summarized:
+            cards.append(summarized)
+
+    # Déduplication basique en gardant l'ordre d'apparition.
+    seen = set()
+    unique_cards: List[Flashcard] = []
+    for card in cards:
+        key = (card.front, card.back)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_cards.append(card)
+    return unique_cards
+
+
+def build_anki_deck(cards: List[Flashcard], title: str) -> str:
+    """Build an Anki deck file (.apkg) from flashcards.
+
+    Args:
+        cards: Flashcards to include in the deck.
+        title: Deck title, typically derived from the input file name.
+
+    Returns:
+        The path to the generated temporary .apkg file.
+    """
+
+    if not cards:
+        raise FlashcardGenerationError(
+            "Aucune carte n'a pu être générée. Vérifiez la structure du PDF."
+        )
+
+    model = genanki.Model(
+        model_id=1607392319,
+        name="PDF2Anki Basic",
+        fields=[{"name": "Question"}, {"name": "Answer"}],
+        templates=[
+            {
+                "name": "Card 1",
+                "qfmt": "{{Question}}",
+                "afmt": "{{FrontSide}}<hr id=answer>{{Answer}}",
+            }
+        ],
+    )
+
+    deck = genanki.Deck(deck_id=2059400110, name=title)
+    for index, card in enumerate(cards, start=1):
+        note = genanki.Note(model=model, fields=[card.front, card.back], guid=str(index))
+        deck.add_note(note)
+
+    package = genanki.Package(deck)
+    temp_file = tempfile.NamedTemporaryFile(suffix=".apkg", delete=False)
+    package.write_to_file(temp_file.name)
+    return temp_file.name

--- a/backend/app/flashcards.py
+++ b/backend/app/flashcards.py
@@ -82,19 +82,49 @@ def _summarize_paragraph(paragraph: str) -> Flashcard | None:
     return Flashcard(front=front, back=back)
 
 
+def _normalize_field(value: str) -> str:
+    """Remove bullet symbols, numbering and generic prefixes."""
+
+    text = value.strip()
+    text = re.sub(r"^[\-–•●]+\s*", "", text)
+    text = re.sub(r"^\(?[0-9]+[\.)]\s*", "", text)
+    text = re.sub(r"^\(?[ivxlcdm]+[\.)]\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^(?:question|questions|réponse|réponses)\s*[:\-]\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^(?:des\s+)?questions?\s+sur\s+documents?\b", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^question\s+longue\b", "", text, flags=re.IGNORECASE)
+    return text.strip()
+
+
+def _is_substantive(text: str) -> bool:
+    if not text:
+        return False
+    words = re.findall(r"[A-Za-zÀ-ÖØ-öø-ÿ]+", text.lower())
+    if not words:
+        return False
+    banned = {"question", "questions", "réponse", "réponses", "document", "documents", "vocabulaire"}
+    if len(words) == 1 and words[0] in banned:
+        return False
+    if len(text) < 3:
+        return False
+    first_word = words[0]
+    if first_word in {"question", "questions", "réponse", "réponses"} and len(words) <= 2:
+        return False
+    return True
+
+
 def _clean_cards(cards: Iterable[Flashcard]) -> List[Flashcard]:
     seen = set()
     unique_cards: List[Flashcard] = []
     for card in cards:
-        key = (card.front.strip(), card.back.strip())
-        if not card.front.strip() or not card.back.strip():
+        front = _normalize_field(card.front)
+        back = _normalize_field(card.back)
+        if not _is_substantive(front) or not _is_substantive(back):
             continue
+        key = (front, back)
         if key in seen:
             continue
         seen.add(key)
-        unique_cards.append(
-            Flashcard(front=card.front.strip(), back=card.back.strip())
-        )
+        unique_cards.append(Flashcard(front=front, back=back))
     return unique_cards
 
 
@@ -140,12 +170,14 @@ def _call_chatgpt_for_cards(text: str, max_cards: int = 40) -> List[Flashcard]:
 
     system_prompt = (
         "Tu es un expert en pédagogie qui crée des cartes mémoire Anki au format question/réponse. "
-        "Respecte le contenu fourni et réponds en JSON pur."
+        "Sélectionne uniquement des connaissances factuelles utiles pour réviser : définitions, dates, événements, concepts, "
+        "pas de consignes méthodologiques ou métacommentaires. Réponds en JSON pur."
     )
     user_prompt = (
-        "Extrait jusqu'à {max_cards} cartes mémoire pertinentes du texte suivant. "
-        "Réponds uniquement en JSON avec la forme: {{\"flashcards\": [{{\"front\": \"...\", \"back\": \"...\"}}]}}. "
-        "Pas de texte hors JSON.\n\nTexte:\n{texte}"
+        "À partir du texte suivant, identifie les informations clés à mémoriser (faits historiques, notions importantes, définitions). "
+        "Ignore les indications de méthode, les consignes d'examen ou les phrases qui n'apportent pas de connaissance. "
+        "Génère au maximum {max_cards} cartes pertinentes et réponds uniquement en JSON au format "
+        "{{\"flashcards\": [{{\"front\": \"...\", \"back\": \"...\"}}]}} sans autre texte.\n\nTexte:\n{texte}"
     ).format(max_cards=max_cards, texte=trimmed_text)
 
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import BackgroundTasks, FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+
+from .flashcards import (
+    FlashcardGenerationError,
+    build_anki_deck,
+    build_flashcards_from_text,
+    extract_pdf_text,
+)
+
+
+def _cleanup_file(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:  # pragma: no cover - best effort cleanup
+        pass
+
+app = FastAPI(title="PDF vers Anki", version="1.0.0")
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/api/generate")
+async def generate_deck(
+    background_tasks: BackgroundTasks, pdf: UploadFile = File(...)
+) -> FileResponse:
+    allowed_types = {"application/pdf", "application/x-pdf", "application/acrobat", "application/octet-stream"}
+    if pdf.content_type not in allowed_types:
+        raise HTTPException(status_code=400, detail="Le fichier doit être un PDF.")
+
+    raw_data = await pdf.read()
+    if not raw_data:
+        raise HTTPException(status_code=400, detail="Le fichier est vide.")
+
+    try:
+        text = extract_pdf_text(raw_data)
+        cards = build_flashcards_from_text(text)
+        deck_title = Path(pdf.filename or "Deck PDF").stem or "Deck PDF"
+        deck_path = build_anki_deck(cards, deck_title)
+    except FlashcardGenerationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    filename = f"{deck_title}.apkg"
+
+    background_tasks.add_task(_cleanup_file, Path(deck_path))
+
+    return FileResponse(
+        path=deck_path,
+        filename=filename,
+        media_type="application/apkg",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 
 from fastapi import BackgroundTasks, FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
 
 from .flashcards import (
     FlashcardGenerationError,
@@ -35,7 +35,7 @@ app.add_middleware(
 @app.post("/api/generate")
 async def generate_deck(
     background_tasks: BackgroundTasks, pdf: UploadFile = File(...)
-) -> FileResponse:
+):
     allowed_types = {"application/pdf", "application/x-pdf", "application/acrobat", "application/octet-stream"}
     if pdf.content_type not in allowed_types:
         raise HTTPException(status_code=400, detail="Le fichier doit être un PDF.")
@@ -54,10 +54,15 @@ async def generate_deck(
 
     filename = f"{deck_title}.apkg"
 
+    deck_bytes = Path(deck_path).read_bytes()
+    deck_base64 = base64.b64encode(deck_bytes).decode("ascii")
+
     background_tasks.add_task(_cleanup_file, Path(deck_path))
 
-    return FileResponse(
-        path=deck_path,
-        filename=filename,
-        media_type="application/apkg",
-    )
+    serialized_cards = [{"front": card.front, "back": card.back} for card in cards]
+
+    return {
+        "deck_filename": filename,
+        "deck_data": deck_base64,
+        "cards": serialized_cards,
+    }

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.1.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.27.1
 PyPDF2==3.0.1
 genanki==0.13.1
 python-multipart==0.0.9
+openai>=1.30.0,<2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+PyPDF2==3.0.1
+genanki==0.13.1
+python-multipart==0.0.9

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -6,6 +6,7 @@ from backend.app.flashcards import (
     build_anki_deck,
     build_flashcards_from_text,
     build_flashcards_with_heuristics,
+    _clean_cards,
 )
 from backend.app import main as main_module
 from fastapi.testclient import TestClient
@@ -44,6 +45,19 @@ def test_build_anki_deck():
     deck_path = build_anki_deck(cards, "Test Deck")
     assert deck_path.endswith(".apkg")
     Path(deck_path).unlink()
+
+
+def test_clean_cards_filters_non_knowledge_entries():
+    raw_cards = [
+        Flashcard(front="- Question longue", back="rédiger une réponse ordonnée"),
+        Flashcard(front="Des questions sur documents", back="il faut garder un regard critique"),
+        Flashcard(front="Diktat", back="Nom donné au traité de Versailles par les Allemands pour souligner son injustice."),
+    ]
+
+    cleaned = _clean_cards(raw_cards)
+
+    assert len(cleaned) == 1
+    assert cleaned[0].front == "Diktat"
 
 
 def test_generate_endpoint_returns_preview(monkeypatch, tmp_path):

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -1,3 +1,4 @@
+import base64
 from pathlib import Path
 
 from backend.app.flashcards import (
@@ -6,6 +7,8 @@ from backend.app.flashcards import (
     build_flashcards_from_text,
     build_flashcards_with_heuristics,
 )
+from backend.app import main as main_module
+from fastapi.testclient import TestClient
 
 
 def test_build_flashcards_with_heuristics_term_definition():
@@ -41,3 +44,32 @@ def test_build_anki_deck():
     deck_path = build_anki_deck(cards, "Test Deck")
     assert deck_path.endswith(".apkg")
     Path(deck_path).unlink()
+
+
+def test_generate_endpoint_returns_preview(monkeypatch, tmp_path):
+    monkeypatch.setattr(main_module, "extract_pdf_text", lambda data: "Term: Definition")
+    monkeypatch.setattr(
+        main_module,
+        "build_flashcards_from_text",
+        lambda text: [Flashcard(front="Q", back="A")],
+    )
+
+    deck_path = tmp_path / "deck.apkg"
+
+    def fake_build_anki_deck(cards, title):
+        deck_path.write_bytes(b"dummy")
+        return str(deck_path)
+
+    monkeypatch.setattr(main_module, "build_anki_deck", fake_build_anki_deck)
+
+    client = TestClient(main_module.app)
+    response = client.post(
+        "/api/generate",
+        files={"pdf": ("test.pdf", b"data", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deck_filename"] == "test.apkg"
+    assert payload["cards"] == [{"front": "Q", "back": "A"}]
+    assert base64.b64decode(payload["deck_data"]) == b"dummy"

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from backend.app.flashcards import build_flashcards_from_text, build_anki_deck, Flashcard
+
+
+def test_build_flashcards_from_text_term_definition():
+    text = """Python: Un langage de programmation.
+
+JavaScript: Langage pour le web."""
+    cards = build_flashcards_from_text(text)
+    assert len(cards) == 2
+    assert cards[0].front == "Python"
+    assert "langage" in cards[0].back
+
+
+def test_build_flashcards_from_text_paragraph_summary():
+    text = (
+        "Le cycle de l'eau commence par l'évaporation. L'eau s'élève, se condense"
+        " et retombe sous forme de précipitations. Ce cycle maintient l'équilibre hydrique."
+    )
+    cards = build_flashcards_from_text(text)
+    assert len(cards) == 1
+    assert "évaporation" in cards[0].front
+    assert "précipitations" in cards[0].back
+
+
+def test_build_anki_deck():
+    cards = [Flashcard(front="Question", back="Réponse")]
+    deck_path = build_anki_deck(cards, "Test Deck")
+    assert deck_path.endswith(".apkg")
+    Path(deck_path).unlink()

--- a/backend/tests/test_flashcards.py
+++ b/backend/tests/test_flashcards.py
@@ -1,27 +1,39 @@
 from pathlib import Path
 
-from backend.app.flashcards import build_flashcards_from_text, build_anki_deck, Flashcard
+from backend.app.flashcards import (
+    Flashcard,
+    build_anki_deck,
+    build_flashcards_from_text,
+    build_flashcards_with_heuristics,
+)
 
 
-def test_build_flashcards_from_text_term_definition():
+def test_build_flashcards_with_heuristics_term_definition():
     text = """Python: Un langage de programmation.
 
 JavaScript: Langage pour le web."""
-    cards = build_flashcards_from_text(text)
+    cards = build_flashcards_with_heuristics(text)
     assert len(cards) == 2
     assert cards[0].front == "Python"
     assert "langage" in cards[0].back
 
 
-def test_build_flashcards_from_text_paragraph_summary():
+def test_build_flashcards_with_heuristics_paragraph_summary():
     text = (
         "Le cycle de l'eau commence par l'évaporation. L'eau s'élève, se condense"
         " et retombe sous forme de précipitations. Ce cycle maintient l'équilibre hydrique."
     )
-    cards = build_flashcards_from_text(text)
+    cards = build_flashcards_with_heuristics(text)
     assert len(cards) == 1
     assert "évaporation" in cards[0].front
     assert "précipitations" in cards[0].back
+
+
+def test_build_flashcards_from_text_without_openai(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cards = build_flashcards_from_text("Python: Langage")
+    assert len(cards) == 1
+    assert cards[0].front == "Python"
 
 
 def test_build_anki_deck():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF vers Anki</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.4.21"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.4",
-    "vite": "^5.1.4"
+    "@vitejs/plugin-vue": "^4.5.0",
+    "vite": "^4.5.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pdf2anki-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "vite": "^5.1.4"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,61 @@
+<template>
+  <main class="app-shell">
+    <header class="hero">
+      <h1>PDF ➜ Anki</h1>
+      <p>Transformez vos documents PDF en cartes mémoire prêtes à réviser.</p>
+    </header>
+    <section class="card">
+      <PdfUploader />
+    </section>
+    <footer class="footer">
+      <p>
+        Déposez votre fichier PDF, générez un deck Anki et téléchargez le pour vos révisions.
+      </p>
+    </footer>
+  </main>
+</template>
+
+<script setup>
+import PdfUploader from './components/PdfUploader.vue'
+</script>
+
+<style scoped>
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 2rem;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.hero {
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.2rem);
+  margin-bottom: 0.5rem;
+  color: #1d4ed8;
+}
+
+.hero p {
+  margin: 0;
+  color: #475569;
+  font-size: 1.125rem;
+}
+
+.card {
+  width: min(680px, 100%);
+  background: white;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.12);
+}
+
+.footer {
+  text-align: center;
+  color: #64748b;
+  max-width: 620px;
+}
+</style>

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -1,0 +1,20 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f5f7fb;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+#app {
+  min-height: 100vh;
+}
+
+button {
+  font: inherit;
+}

--- a/frontend/src/components/PdfUploader.vue
+++ b/frontend/src/components/PdfUploader.vue
@@ -19,8 +19,36 @@
 
     <transition name="fade">
       <div v-if="success" class="alert alert--success">
-        Deck généré ! <a :href="downloadUrl" download>Cliquer ici pour télécharger</a>.
+        Cartes générées ! Vérifiez la prévisualisation ci-dessous avant de télécharger le deck.
       </div>
+    </transition>
+
+    <transition name="fade">
+      <section v-if="cards.length" class="preview">
+        <header class="preview__header">
+          <div>
+            <h3>Prévisualisation des cartes</h3>
+            <p>{{ cards.length }} carte<span v-if="cards.length > 1">s</span> générée<span v-if="cards.length > 1">s</span>.</p>
+          </div>
+          <a
+            v-if="downloadUrl"
+            class="button-primary preview__download"
+            :href="downloadUrl"
+            :download="downloadFilename"
+          >
+            Télécharger le deck Anki
+          </a>
+        </header>
+        <ul class="preview__list">
+          <li v-for="(card, index) in cards" :key="`${index}-${card.front}`" class="preview__card">
+            <h4>Carte {{ index + 1 }}</h4>
+            <p class="preview__label">Question</p>
+            <p class="preview__content" v-html="card.front"></p>
+            <p class="preview__label">Réponse</p>
+            <p class="preview__content" v-html="card.back"></p>
+          </li>
+        </ul>
+      </section>
     </transition>
 
     <button type="submit" class="button-primary" :disabled="isLoading">
@@ -44,10 +72,13 @@ const success = ref(false)
 const isLoading = ref(false)
 const isDragging = ref(false)
 const downloadUrl = ref('')
+const downloadFilename = ref('deck.apkg')
+const cards = ref([])
 
 const resetFeedback = () => {
   error.value = ''
   success.value = false
+  cards.value = []
   if (downloadUrl.value) {
     URL.revokeObjectURL(downloadUrl.value)
     downloadUrl.value = ''
@@ -115,8 +146,22 @@ const submit = async () => {
       throw new Error(payload.detail || 'La génération a échoué.')
     }
 
-    const blob = await response.blob()
+    const payload = await response.json()
+    if (!payload?.deck_data || !Array.isArray(payload?.cards)) {
+      throw new Error('Réponse inattendue du serveur.')
+    }
+
+    const binary = Uint8Array.from(atob(payload.deck_data), (char) => char.charCodeAt(0))
+    const blob = new Blob([binary], { type: 'application/apkg' })
+
     downloadUrl.value = URL.createObjectURL(blob)
+    downloadFilename.value = payload.deck_filename || 'deck.apkg'
+    const sanitizedCards = payload.cards.map((card) => ({
+      front: String(card?.front ?? ''),
+      back: String(card?.back ?? '')
+    }))
+
+    cards.value = sanitizedCards
     success.value = true
   } catch (err) {
     error.value = err.message
@@ -176,10 +221,90 @@ const submit = async () => {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.button-primary {
+.button-primary { 
   background: linear-gradient(135deg, #2563eb, #3b82f6);
   color: white;
   box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+}
+
+.preview {
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  border-radius: 16px;
+  padding: 1.5rem;
+  background: rgba(219, 234, 254, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.preview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.preview__header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #1f2937;
+}
+
+.preview__header p {
+  margin: 0.25rem 0 0;
+  color: #374151;
+}
+
+.preview__download {
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.preview__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.preview__card {
+  background: white;
+  border-radius: 14px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.preview__card h4 {
+  margin: 0;
+  color: #1d4ed8;
+  font-size: 1rem;
+}
+
+.preview__label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+}
+
+.preview__content {
+  margin: 0;
+  color: #111827;
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 10px;
+  padding: 0.75rem;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.preview__content :deep(br) {
+  content: '';
 }
 
 .button-primary:disabled {

--- a/frontend/src/components/PdfUploader.vue
+++ b/frontend/src/components/PdfUploader.vue
@@ -1,0 +1,263 @@
+<template>
+  <form class="uploader" @submit.prevent="submit">
+    <label class="dropzone" :class="{ 'dropzone--drag': isDragging }" @dragenter.prevent="onDrag(true)" @dragleave.prevent="onDrag(false)" @dragover.prevent @drop.prevent="handleDrop">
+      <input ref="fileInput" type="file" accept="application/pdf" @change="handleFileChange" hidden />
+      <div class="dropzone__content">
+        <h2>Glissez un PDF ici ou cliquez pour sélectionner</h2>
+        <p>Nous générerons automatiquement un deck Anki basé sur son contenu.</p>
+        <button type="button" class="button-secondary" @click="pickFile">Choisir un fichier</button>
+      </div>
+    </label>
+
+    <transition name="fade">
+      <p v-if="fileName" class="file-name">Fichier sélectionné : {{ fileName }}</p>
+    </transition>
+
+    <transition name="fade">
+      <div v-if="error" class="alert alert--error">{{ error }}</div>
+    </transition>
+
+    <transition name="fade">
+      <div v-if="success" class="alert alert--success">
+        Deck généré ! <a :href="downloadUrl" download>Cliquer ici pour télécharger</a>.
+      </div>
+    </transition>
+
+    <button type="submit" class="button-primary" :disabled="isLoading">
+      <span v-if="!isLoading">Générer le deck</span>
+      <span v-else class="loader">
+        <span class="loader__spinner" />
+        Traitement en cours...
+      </span>
+    </button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const fileInput = ref(null)
+const file = ref(null)
+const fileName = ref('')
+const error = ref('')
+const success = ref(false)
+const isLoading = ref(false)
+const isDragging = ref(false)
+const downloadUrl = ref('')
+
+const resetFeedback = () => {
+  error.value = ''
+  success.value = false
+  if (downloadUrl.value) {
+    URL.revokeObjectURL(downloadUrl.value)
+    downloadUrl.value = ''
+  }
+}
+
+const pickFile = () => {
+  fileInput.value?.click()
+}
+
+const handleFileChange = (event) => {
+  resetFeedback()
+  const [selected] = event.target.files
+  if (!selected) {
+    file.value = null
+    fileName.value = ''
+    return
+  }
+  if (selected.type !== 'application/pdf') {
+    error.value = 'Seuls les fichiers PDF sont acceptés.'
+    file.value = null
+    fileName.value = ''
+    return
+  }
+  file.value = selected
+  fileName.value = selected.name
+}
+
+const handleDrop = (event) => {
+  isDragging.value = false
+  if (!event.dataTransfer?.files?.length) return
+  const dropped = event.dataTransfer.files[0]
+  if (dropped.type !== 'application/pdf') {
+    error.value = 'Seuls les fichiers PDF sont acceptés.'
+    return
+  }
+  file.value = dropped
+  fileName.value = dropped.name
+  resetFeedback()
+}
+
+const onDrag = (state) => {
+  isDragging.value = state
+}
+
+const submit = async () => {
+  resetFeedback()
+  if (!file.value) {
+    error.value = 'Merci de sélectionner un fichier PDF avant de lancer la génération.'
+    return
+  }
+  isLoading.value = true
+
+  try {
+    const formData = new FormData()
+    formData.append('pdf', file.value)
+
+    const response = await fetch('/api/generate', {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}))
+      throw new Error(payload.detail || 'La génération a échoué.')
+    }
+
+    const blob = await response.blob()
+    downloadUrl.value = URL.createObjectURL(blob)
+    success.value = true
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dropzone {
+  border: 2px dashed #cbd5f5;
+  border-radius: 18px;
+  padding: 2.5rem;
+  background: rgba(229, 231, 235, 0.4);
+  transition: border-color 0.3s, background 0.3s;
+  cursor: pointer;
+}
+
+.dropzone--drag {
+  border-color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.dropzone__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.dropzone h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1f2937;
+}
+
+.dropzone p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.button-primary,
+.button-secondary {
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: white;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+}
+
+.button-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button-secondary {
+  background: white;
+  color: #1d4ed8;
+  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.18);
+}
+
+.button-primary:not(:disabled):hover,
+.button-secondary:hover {
+  transform: translateY(-2px);
+}
+
+.file-name {
+  margin: 0;
+  color: #334155;
+  font-weight: 600;
+}
+
+.alert {
+  padding: 1rem 1.2rem;
+  border-radius: 14px;
+  font-weight: 500;
+}
+
+.alert--error {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+}
+
+.alert--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.alert a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.loader {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.loader__spinner {
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 3px solid rgba(255, 255, 255, 0.6);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './assets/base.css'
+
+createApp(App).mount('#app')

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add a FastAPI backend that extracts text from PDFs, generates flashcards, and bundles them into downloadable Anki decks
- cover the flashcard heuristics with tests and document project setup and workflows
- scaffold a Vue 3 + Vite interface with drag-and-drop PDF upload and API proxy configuration

## Testing
- Not Run (pip and npm installs blocked by network proxy)


------
https://chatgpt.com/codex/tasks/task_e_68e62845afc88328a433f29bddaaa65d